### PR TITLE
More updates to the patroni module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,7 @@ class patroni (
   Enum['http','https'] $consul_scheme = $patroni::params::consul_scheme,
   Variant[Undef,String] $consul_token   = undef,
   Boolean $consul_verify = $patroni::params::consul_verify,
+  Optional[Boolean] $consul_register_service = undef,
   Variant[Undef,String] $consul_cacert  = undef,
   Variant[Undef,String] $consul_cert    = undef,
   Variant[Undef,String] $consul_key     = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -135,10 +135,10 @@ class patroni (
     $pgsql_parameters_all = lookup( { 'name'          => 'patroni::pgsql_parameters',
                                       'value_type'    => undef,
                                       'merge'         => {
-                                         'strategy'   => 'deep',
-                                       }, 
+                                        'strategy'   => 'deep',
+                                      },
                                       'default_value' => $pgsql_parameters,
-                                     })
+                                    })
   } else {
     $pgsql_parameters_all = $pgsql_parameters
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class patroni (
   Boolean $pgsql_use_unix_socket       = $patroni::params::pgsql_use_unix_socket,
   String $pgsql_pgpass_path            = $patroni::params::pgsql_pgpass_path,
   Hash $pgsql_recovery_conf            = {},
-  Hash $pgsql_custom_conf              = {},
+  Variant[Undef,String]  $pgsql_custom_conf           = undef,
   Hash $pgsql_parameters               = {},
   Array[String] $pgsql_pg_hba          = [],
   Integer $pgsql_pg_ctl_timeout        = $patroni::params::pgsql_pg_ctl_timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class patroni (
   Array[String] $pgsql_pg_hba          = [],
   Integer $pgsql_pg_ctl_timeout        = $patroni::params::pgsql_pg_ctl_timeout,
   Boolean $pgsql_use_pg_rewind         = $patroni::params::pgsql_use_pg_rewind,
+  Boolean $hiera_merge_pgsql_parameters = $patroni::params::hiera_merge_pgsql_parameters,
   Boolean $pgsql_remove_data_directory_on_rewind_failure = $patroni::params::pgsql_remove_data_directory_on_rewind_failure,
   Array[Hash] $pgsql_replica_method    = [],
 
@@ -129,6 +130,19 @@ class patroni (
   Boolean $restart_service = $patroni::params::restart_service,
 
 ) inherits patroni::params {
+
+  if $hiera_merge_pgsql_parameters == true {
+    $pgsql_parameters_all = lookup( { 'name'          => 'patroni::pgsql_parameters',
+                                      'value_type'    => undef,
+                                      'merge'         => {
+                                         'strategy'   => 'deep',
+                                       }, 
+                                      'default_value' => $pgsql_parameters,
+                                     })
+  } else {
+    $pgsql_parameters_all = $pgsql_parameters
+  }
+
   anchor{'patroni::begin':}
   -> class{'::patroni::install':}
   -> class{'::patroni::config':}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class patroni::params {
 
   $pgsql_pg_ctl_timeout         = 60
   $pgsql_use_pg_rewind          = true
+  $hiera_merge_pgsql_parameters = false
   $pgsql_remove_data_directory_on_rewind_failure = false
 
   $use_consul    = false

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -259,4 +259,7 @@ consul:
 <% if @consul_checks != nil -%>
   checks: <%= @consul_checks %>
 <% end -%>
+<% if @consul_register_service != nil -%>
+  register_service: <%= @consul_register_service %>
+<% end -%>
 <% end -%>

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -119,9 +119,9 @@ postgresql:
     <%= name -%>: <%= val %>
 <% end -%>
 <% end -%>
-<% unless @pgsql_parameters.empty? -%>
+<% unless @pgsql_parameters_all.empty? -%>
   parameters:
-<% @pgsql_parameters.each do |name,val| -%>
+<% @pgsql_parameters_all.each do |name,val| -%>
     <%= name -%>: <%= val %>
 <% end -%>
 <% end -%>

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -10,7 +10,7 @@ bootstrap:
     maximum_lag_on_failover: <%= @dcs_maximum_lag_on_failover %>
     master_start_timeout: <%= @dcs_master_start_timeout %>
     synchronous_mode: <%= @dcs_synchronous_mode %>
-    synchronous_mode_struct: <%= @dcs_synchronous_mode_strict %>
+    synchronous_mode_strict: <%= @dcs_synchronous_mode_strict %>
     postgresql:
       use_pg_rewind: <%= @dcs_postgresql_use_pg_rewind ? 'true' : 'false' %>
       use_slots: <%= @dcs_postgresql_use_slots ? 'true' : 'false' %>

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -113,11 +113,8 @@ postgresql:
     <%= name -%>: <%= val %>
 <% end -%>
 <% end -%>
-<% unless @pgsql_custom_conf.empty? -%>
-  custom_conf:
-<% @pgsql_custom_conf.each do |name,val| -%>
-    <%= name -%>: <%= val %>
-<% end -%>
+<% if @pgsql_custom_conf != nil -%>
+  pgsql_custom_conf: <%= @pgsql_custom_conf %>
 <% end -%>
 <% unless @pgsql_parameters_all.empty? -%>
   parameters:


### PR DESCRIPTION
This pull request contains for followings changes.
1. Corrected a typo error in template (synchronous_mode_struct to synchronous_mode_strict)
2. Added support for consul register_service configuration (This parameter decides whether or not to register a service with the name defined by the scope parameter and the tag master, replica or standby-leader depending on the node’s role.)
3. Added support to merge pgsql_parameters defined in different levels of hiera. To merge the parameters, user should set the value of hiera_merge_pgsql_parameters to 'true'.
4. Updated the datatype of custom_conf to a String (Patroni uses custom_conf to define a file path and datatype can not be a Hash.)
