### PR TITLE
Fix an error introduced in previous commit b2e8ffb

### DIFF
--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -120,7 +120,7 @@ postgresql:
 <% end -%>
 <% end -%>
 <% if @pgsql_custom_conf != nil -%>
-  pgsql_custom_conf: <%= @pgsql_custom_conf %>
+  custom_conf: <%= @pgsql_custom_conf %>
 <% end -%>
 <% unless @pgsql_parameters_all.empty? -%>
   parameters:


### PR DESCRIPTION
Hi, This commit fix a typo error introduced in previous commit b2e8ffb (sorry).
