### PR TITLE
Support for Debian, latest consul config options and custom service restart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.1.3
+
+* Added support for the latest consul configuration options - consistency, service_check_interval
+* Added support for custom patroni service restart command (useful for reload only)
+* Added support for Debian
+
 ## Release 0.1.2
 
 ### BREAKING CHANGES (sort of, didn't work previously)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,8 @@ class patroni (
   Variant[Undef,String] $consul_token   = undef,
   Boolean $consul_verify = $patroni::params::consul_verify,
   Optional[Boolean] $consul_register_service = undef,
+  Optional[String] $consul_service_check_interval = undef,
+  Optional[Enum['default', 'consistent', 'stale']] $consul_consistency = undef,
   Variant[Undef,String] $consul_cacert  = undef,
   Variant[Undef,String] $consul_cert    = undef,
   Variant[Undef,String] $consul_key     = undef,
@@ -128,6 +130,7 @@ class patroni (
   String $ensure_service  = $patroni::params::ensure_service,
   Boolean $enable_service  = $patroni::params::enable_service,
   Boolean $restart_service = $patroni::params::restart_service,
+  Optional[String] $restart_service_command = undef,
 
 ) inherits patroni::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,7 +111,7 @@ class patroni::params {
         }
         default: {
           warning("This operating system version (${::operatingsystemmajrelease}) is not supported.
-                  '$pgsql_data_dir' must be specified manually.")
+                  'pgsql_data_dir' variable must be specified manually.")
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,6 +91,30 @@ class patroni::params {
         }
       }
     }
+    'Debian': {
+      $servicename = 'patroni'
+      $packagename = 'patroni'
+      $config_path = '/etc/patroni/config.yml'
+      $config_owner = 'root'
+      $config_group = 'root'
+      $config_mode  = '0644'
+      $initdb_locale = 'en_US.utf8'
+      case $::operatingsystemmajrelease {
+        '8': {
+          $pgsql_data_dir   = '/var/lib/postgresql/9.4/patroni'
+        }
+        '9': {
+          $pgsql_data_dir   = '/var/lib/postgresql/9.6/patroni'
+        }
+        '10': {
+          $pgsql_data_dir   = '/var/lib/postgresql/11/patroni'
+        }
+        default: {
+          warning("This operating system version (${::operatingsystemmajrelease}) is not supported.
+                  '$pgsql_data_dir' must be specified manually.")
+        }
+      }
+    }
     default: {
       fail("This operating system family (${::osfamily}) is not supported.")
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,8 @@
 # Manage Patroni service
 class patroni::service inherits patroni {
   service { $::patroni::servicename:
-    ensure => $::patroni::ensure_service,
-    enable => $::patroni::enable_service,
+    ensure  => $::patroni::ensure_service,
+    enable  => $::patroni::enable_service,
+    restart => $::patroni::restart_service_command,
   }
 }

--- a/templates/postgresql.yml.erb
+++ b/templates/postgresql.yml.erb
@@ -259,10 +259,16 @@ consul:
 <% if @consul_dc != nil -%>
   dc: <%= @consul_dc %>
 <% end -%>
+<% if @consul_consistency != nil -%>
+  consistency: <%= @consul_consistency %>
+<% end -%>
 <% if @consul_checks != nil -%>
   checks: <%= @consul_checks %>
 <% end -%>
 <% if @consul_register_service != nil -%>
   register_service: <%= @consul_register_service %>
+<% end -%>
+<% if @consul_service_check_interval != nil -%>
+  service_check_interval: <%= @consul_service_check_interval %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This commit adds the following features:

- support Debian OS
- support for not yet included consul configuration options (consistency, service check interval)
- support for specifying a custom patroni service restart command. This works only when `restart_service` is set to `true`. It allows to set the behavior of the patroni service refresh action when the config file changes. It can be set to `/usr/bin/systemctl reload patroni` and then it will automatically reload the `patroni` service on config changes. Restart must be performed manually, though.